### PR TITLE
linux aarch64 (ARM)

### DIFF
--- a/handler/Makefile
+++ b/handler/Makefile
@@ -19,6 +19,12 @@ linux: $(BUILD_DIR)/x86_64-unknown-linux.hex
 mac: $(BUILD_DIR)/x86_64-apple-darwin.hex
 windows: $(BUILD_DIR)/x86_64-pc-windows.hex
 
+linux-aarch64:
+	mkdir -p $(BUILD_DIR)
+	clang -c -O3 -Werror -target aarch64-unknown-linux -o $(BUILD_DIR)/aarch64-unknown-linux.o ./handler_ptr.c -mcmodel=tiny
+	ld $(BUILD_DIR)/aarch64-unknown-linux.o -o $(BUILD_DIR)/a.out
+	objdump -s -j .text $(BUILD_DIR)/a.out | awk '/\.text/{flag=1; next} flag{print}' | awk -F' ' '{print $$2 $$3 $$4 $$5}' | tr -d ' \n' > $(BUILD_DIR)/aarch64-unknown-linux.hex
+
 clean:
 	rm -f $(BUILD_DIR)/*.o
 	rm -f $(BUILD_DIR)/*.hex

--- a/handler/handler_ptr.c
+++ b/handler/handler_ptr.c
@@ -1,0 +1,15 @@
+__attribute__((section(".text")))
+const void *handler_address = (void *)(0xaaaaaaaaaaaaaaaa);
+__attribute__((section(".text")))
+const void *PyObject_Call_address = (void *)(0xbbbbbbbbbbbbbbbb);
+__attribute__((section(".text")))
+__attribute__((used)) static void *
+handler(void *self, void *args, void *kwargs)
+{
+    void *result = ((void *(*)(void *, void *, void *))(PyObject_Call_address))(
+        (void *)(handler_address),
+        args,
+        kwargs);
+
+    return result;
+}

--- a/intercepts/_handlers/__init__.py
+++ b/intercepts/_handlers/__init__.py
@@ -7,7 +7,7 @@ import typing
 
 from .base import PTR_SIZE, get_addr, replace_cfunction_base
 
-if platform.machine() not in {"x86_64", "AMD64"}:  # pragma: no cover
+if platform.machine() not in {"x86_64", "AMD64", "aarch64"}:  # pragma: no cover
     raise ImportError(f"Unfortunately {platform.machine()} is not currently supported.")
 if sys.byteorder != "little":  # pragma: no cover
     raise ImportError(

--- a/intercepts/_handlers/linux.py
+++ b/intercepts/_handlers/linux.py
@@ -7,9 +7,11 @@ import platform
 
 from .base import PyObject_Call_address
 
-if platform.machine() == "aarch64" :
-    INSTR_TEMPLATE = bytes.fromhex("c30000586000005860001fd61f2003d5aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb")
-else :
+if platform.machine() == "aarch64":
+    INSTR_TEMPLATE = bytes.fromhex(
+        "c30000586000005860001fd61f2003d5aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb"
+    )
+else:
     INSTR_TEMPLATE = bytes.fromhex("48bfaaaaaaaaaaaaaaaa48b8bbbbbbbbbbbbbbbbffe0")
 _i = INSTR_TEMPLATE.index(b"\xbb" * 8)
 INSTR_TEMPLATE = INSTR_TEMPLATE[:_i] + PyObject_Call_address + INSTR_TEMPLATE[_i + 8 :]

--- a/intercepts/_handlers/linux.py
+++ b/intercepts/_handlers/linux.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import ctypes
 import os
 import typing
+import platform
 
 from .base import PyObject_Call_address
 
-INSTR_TEMPLATE = bytes.fromhex("48bfaaaaaaaaaaaaaaaa48b8bbbbbbbbbbbbbbbbffe0")
+if platform.machine() == "aarch64" :
+    INSTR_TEMPLATE = bytes.fromhex("c30000586000005860001fd61f2003d5aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb")
+else :
+    INSTR_TEMPLATE = bytes.fromhex("48bfaaaaaaaaaaaaaaaa48b8bbbbbbbbbbbbbbbbffe0")
 _i = INSTR_TEMPLATE.index(b"\xbb" * 8)
 INSTR_TEMPLATE = INSTR_TEMPLATE[:_i] + PyObject_Call_address + INSTR_TEMPLATE[_i + 8 :]
 


### PR DESCRIPTION
Here is support for aarch64, issue #7. I created a new `handler_ptr.c` that employs pointers instead of coding addresses inline. I added Makefile target `linux-aarch64` to generate the hex. This commit passes the `pytest` suite and also worked in my application.

In adding this support, I minimized changes to your code vs trying to introduce my methods everywhere as I didn't know what you would want to do there. I think perhaps `handler_ptr.c` could work for all instruction architectures and replace `handler.c`. Also I introduced some changes to how the hex is extracted that should be more universal.