### PR TITLE
Fix illegal instruction issue

### DIFF
--- a/intercepts/_handlers/__init__.py
+++ b/intercepts/_handlers/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import platform
 import sys
 import types
 import typing
@@ -22,7 +21,7 @@ else:  # pragma: no cover
 
 def replace_cfunction(
     obj: types.BuiltinFunctionType, handler: typing.Callable
-) -> typing.Tuple[bytes, bytes]:
+) -> typing.Tuple[bytes, typing.Callable[[], int]]:
     return replace_cfunction_base(obj, handler, malloc, mprotect)
 
 

--- a/intercepts/_handlers/linux.py
+++ b/intercepts/_handlers/linux.py
@@ -7,18 +7,48 @@ import typing
 CDLL = ctypes.CDLL(ctypes.util.find_library("c"))
 PAGESIZE = os.sysconf("SC_PAGE_SIZE")
 
+CDLL.mmap.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+    ctypes.c_uint32,
+]
+CDLL.mmap.restype = ctypes.c_void_p
 
-def malloc(size: int) -> typing.Tuple[int, ctypes.Array[ctypes.c_char]]:
-    pages = ctypes.create_string_buffer(PAGESIZE + size)
-    page_aligned_addr = (ctypes.addressof(pages) + PAGESIZE - 1) & ~(PAGESIZE - 1)
-    return page_aligned_addr, pages
+CDLL.munmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+CDLL.munmap.restype = ctypes.c_int
+
+# From mman.h
+PROT_READ = 0x01  # Page can be read.
+PROT_WRITE = 0x02  # Page can be written.
+PROT_EXEC = 0x04  # Page can be executed.
+
+MAP_SHARED = 0x01  # Share changes.
+MAP_ANONYMOUS = 0x20  # Not backed by a file.
+
+
+def malloc(
+    size: int,
+) -> typing.Tuple[int, typing.Callable[[], int]]:
+    page_aligned_addr = CDLL.mmap(
+        None,
+        size,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED | MAP_ANONYMOUS,
+        0,
+        0,
+    )
+    dealloc = lambda _addr=page_aligned_addr, _size=size: CDLL.munmap(_addr, _size)
+    return page_aligned_addr, dealloc
 
 
 def mprotect(addr: int, size: int) -> None:
     mprotect_result = CDLL.mprotect(
         ctypes.c_void_p(addr),
         ctypes.c_size_t(size),
-        ctypes.c_int(0x01 | 0x02 | 0x04),
+        ctypes.c_int(PROT_READ | PROT_WRITE | PROT_EXEC),
     )
     if mprotect_result:  # pragma: no cover
         # TODO(dlshriver): can we return more information?

--- a/tests/test_python_builtins.py
+++ b/tests/test_python_builtins.py
@@ -337,8 +337,8 @@ def test_builtin(capsys, builtin_func, args, kwargs):
     captured_0 = capsys.readouterr()
     intercepts.register(builtin_func, handler)
     handled_result = builtin_func(*args, **kwargs)
-    captured_1 = capsys.readouterr()
     intercepts.unregister(builtin_func)
+    captured_1 = capsys.readouterr()
     assert handled_result == (
         "handled",
         result,
@@ -372,7 +372,6 @@ def test_input(capsys, monkeypatch):
     test_builtin(capsys, input, ("Input: ",), {})
 
 
-@pytest.mark.xfail(reason="crashes program, must fix")
 @pytest.mark.parametrize(
     "args",
     [
@@ -388,8 +387,8 @@ def test_iter(capsys, args):
     captured_0 = capsys.readouterr()
     intercepts.register(builtin_func, handler)
     handled_result = builtin_func(*args)
-    captured_1 = capsys.readouterr()
     intercepts.unregister(builtin_func)
+    captured_1 = capsys.readouterr()
     assert isinstance(handled_result, tuple)
     assert handled_result[0] == "handled"
     assert list(handled_result[1]) == result


### PR DESCRIPTION
This should be a fix for #10.

I switched to using `mmap` to get memory instead of the string buffer weirdness I had used before. This also means we need to release the memory when intercepts are unregistered since the memory is no longer tracked by the garbage collector.
