### PR TITLE
Don't copy global dict

### DIFF
--- a/intercepts/registration.py
+++ b/intercepts/registration.py
@@ -175,13 +175,7 @@ def _unregister_function_addr(addr: int, depth: int | None = None):
     while handlers.__len__() and depth > 0:
         depth -= 1
         obj, _obj, *_ = handlers.pop()
-        # Reset to previous code and globals values
         obj.__code__ = _obj.__code__
-        ctypes.memmove(
-            addr + 2 * PTR_SIZE,
-            struct.pack("N", get_addr(_obj.__globals__)),
-            PTR_SIZE,
-        )
 
 
 def _unregister_function(obj: types.FunctionType, depth: int | None = None):

--- a/intercepts/registration.py
+++ b/intercepts/registration.py
@@ -121,7 +121,26 @@ def _register_function(
                     [dis.opmap["PUSH_NULL"], 0] + load_const + [dis.opmap["NOP"], 0] * 4
                 ),
             )
-        _code = _code.replace(co_code=_co_code, co_consts=_co_consts)
+        if _PYTHON_VERSION < (3, 8):
+            _code = types.CodeType(
+                _code.co_argcount,
+                _code.co_kwonlyargcount,
+                _code.co_nlocals,
+                _code.co_stacksize,
+                _code.co_flags,
+                _co_code,
+                _co_consts,
+                _code.co_names,
+                _code.co_varnames,
+                _code.co_filename,
+                _code.co_name,
+                _code.co_firstlineno,
+                _code.co_lnotab,
+                _code.co_freevars,
+                _code.co_cellvars,
+            )
+        else:
+            _code = _code.replace(co_code=_co_code, co_consts=_co_consts)
     obj.__code__ = _code
 
     _HANDLERS[get_addr(obj), type(obj)].append((obj, _obj))

--- a/tests/test_dynamic_globals.py
+++ b/tests/test_dynamic_globals.py
@@ -1,5 +1,6 @@
-import intercepts
 import pytest
+
+import intercepts
 
 
 def test_closure():

--- a/tests/test_dynamic_globals.py
+++ b/tests/test_dynamic_globals.py
@@ -1,0 +1,81 @@
+import intercepts
+import pytest
+
+
+def test_closure():
+    def increment():
+        return num + 1
+
+    def handler():
+        result = _()
+        return num - (result - num)
+
+    intercepts.register(increment, handler)
+
+    num = 41
+    assert increment() == 40
+    intercepts.register(increment, handler)
+    assert increment() == 42
+    intercepts.unregister_all()
+    assert increment() == 42
+
+
+def test_missing_name():
+    def increment():
+        return num + 1
+
+    def handler():
+        result = _()
+        return num - (result - num)
+
+    intercepts.register(increment, handler)
+
+    with pytest.raises(NameError):
+        assert increment() == 40
+
+    num = 41
+    assert increment() == 40
+    num = 40
+    assert increment() == 39
+
+
+def test_get_global_value():
+    global NUM
+
+    def increment():
+        global NUM
+        return NUM + 1
+
+    def handler():
+        global NUM
+        result = _()
+        return NUM - (result - NUM)
+
+    intercepts.register(increment, handler)
+
+    NUM = 41
+    assert increment() == 40
+    intercepts.register(increment, handler)
+    assert increment() == 42
+    intercepts.unregister_all()
+    assert increment() == 42
+
+
+def test_set_global_value():
+    def increment():
+        global RESULT
+        RESULT = NUM + 1
+
+    def handler():
+        global RESULT
+        _()
+        return NUM - (RESULT - NUM)
+
+    intercepts.register(increment, handler)
+
+    NUM = 41
+    assert increment() == 40
+    assert RESULT == 42
+    NUM = 42
+    assert increment() == 41
+    assert RESULT == 43

--- a/tests/test_dynamic_globals.py
+++ b/tests/test_dynamic_globals.py
@@ -62,6 +62,8 @@ def test_get_global_value():
 
 
 def test_set_global_value():
+    global RESULT
+
     def increment():
         global RESULT
         RESULT = NUM + 1
@@ -69,13 +71,15 @@ def test_set_global_value():
     def handler():
         global RESULT
         _()
-        return NUM - (RESULT - NUM)
+        RESULT = NUM - (RESULT - NUM)
+        return RESULT
 
     intercepts.register(increment, handler)
 
+    RESULT = 0
     NUM = 41
     assert increment() == 40
-    assert RESULT == 42
+    assert RESULT == 40
     NUM = 42
     assert increment() == 41
-    assert RESULT == 43
+    assert RESULT == 41

--- a/tests/test_independent_handler.py
+++ b/tests/test_independent_handler.py
@@ -1,0 +1,18 @@
+import intercepts
+
+
+def func(a, b):
+    return a + b
+
+
+def handler(*args, **kwargs):
+    print("Preventing call.")
+    return 0
+
+
+def test_intercept(capsys):
+    assert func(3, 5) == 8
+    intercepts.register(func, handler)
+    assert func(3, 5) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "Preventing call.\n"


### PR DESCRIPTION
This change makes it so that updates to global variables can be seen by intercepted function. Previously we would copy the globals dict at registration time, preventing any updates from being seen by either the handler or intercepted function. With this change we no longer need to copy the globals dict to enable access to the intercepted function and instead we modify the bytecode to avoid the lookup of `_`.