### PR TITLE
fix: don't copy or modify globals for builtin handler

### DIFF
--- a/intercepts/_utils.py
+++ b/intercepts/_utils.py
@@ -12,8 +12,7 @@ def replace_load_global(code: types.CodeType, name: str, value: typing.Any):
     if name not in code.co_names:
         return code
     _co_code = code.co_code
-    if value not in code.co_consts:
-        _co_consts = code.co_consts + (value,)
+    _co_consts = code.co_consts + (value,)
     _const_index = _co_consts.index(value)
     _name_index = code.co_names.index(name)
     load_const = [dis.opmap["LOAD_CONST"], _const_index]

--- a/intercepts/_utils.py
+++ b/intercepts/_utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import dis
 import sys
 import types

--- a/intercepts/_utils.py
+++ b/intercepts/_utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import dis
+import sys
+import types
+import typing
+
+_PYTHON_VERSION = sys.version_info[:2]
+
+
+def replace_load_global(code: types.CodeType, name: str, value: typing.Any):
+    if name not in code.co_names:
+        return code
+    _co_code = code.co_code
+    if value not in code.co_consts:
+        _co_consts = code.co_consts + (value,)
+    _const_index = _co_consts.index(value)
+    _name_index = code.co_names.index(name)
+    load_const = [dis.opmap["LOAD_CONST"], _const_index]
+    if _PYTHON_VERSION < (3, 11):
+        _co_code = _co_code.replace(
+            bytes([dis.opmap["LOAD_GLOBAL"], _name_index]),
+            bytes(load_const),
+        )
+    else:
+        # CPython 3.11 has 5 CACHE ops after LOAD_GLOBAL
+        # CPython 3.12 has 4 CACHE ops after LOAD_GLOBAL
+        _cache_len = 5 if _PYTHON_VERSION <= (3, 11) else 4
+        _co_code = _co_code.replace(
+            bytes(
+                [
+                    dis.opmap["LOAD_GLOBAL"],
+                    (_name_index << 1),
+                    *([dis.opmap["CACHE"], 0] * _cache_len),
+                ]
+            ),
+            # Need the NOPs to prevent segfaults with coveragepy and pytest
+            bytes(load_const + [dis.opmap["NOP"], 0] * _cache_len),
+        ).replace(
+            bytes(
+                [
+                    dis.opmap["LOAD_GLOBAL"],
+                    (_name_index << 1) + 1,
+                    *([dis.opmap["CACHE"], 0] * _cache_len),
+                ]
+            ),
+            # Need the NOPs to prevent segfaults with coveragepy and pytest
+            bytes(
+                [dis.opmap["PUSH_NULL"], 0]
+                + load_const
+                + [dis.opmap["NOP"], 0] * (_cache_len - 1)
+            ),
+        )
+    if _PYTHON_VERSION < (3, 8):
+        return types.CodeType(
+            code.co_argcount,
+            code.co_kwonlyargcount,
+            code.co_nlocals,
+            code.co_stacksize,
+            code.co_flags,
+            _co_code,
+            _co_consts,
+            code.co_names,
+            code.co_varnames,
+            code.co_filename,
+            code.co_name,
+            code.co_firstlineno,
+            code.co_lnotab,
+            code.co_freevars,
+            code.co_cellvars,
+        )
+    return code.replace(co_code=_co_code, co_consts=_co_consts)

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -84,3 +84,39 @@ def test_set_global_value():
     NUM = 42
     assert increment() == 41
     assert RESULT == 41
+
+
+def test_get_global_value_handling_builtin():
+    global NUM
+
+    def handler(*args, **kwargs):
+        global NUM
+        result = _(*args, **kwargs)
+        return NUM + 1
+
+    NUM = 41
+    assert sum([3, 8, 2]) == 13
+    intercepts.register(sum, handler)
+    assert sum([3, 8, 2]) == 42
+    NUM = 40
+    assert sum([3, 8, 2]) == 41
+    intercepts.unregister_all()
+    assert sum([3, 8, 2]) == 13
+
+
+def test_set_global_value_handling_builtin():
+    global RESULT
+
+    def handler(*args, **kwargs):
+        global RESULT
+        RESULT = _(*args, **kwargs) + NUM
+        return RESULT - NUM
+
+    assert sum([1, 2, 3, 1]) == 7
+    intercepts.register(sum, handler)
+
+    NUM = 1000
+    RESULT = 0
+    assert RESULT == 0
+    assert sum([1, 2, 3, 1]) == 7
+    assert RESULT == 1007


### PR DESCRIPTION
This change makes modifies the interception of built-in functions to be more similar to that of pure python functions (as changed in #12). It enables updates to global variables to be seen by intercept handler. Previously we would copy the globals dictionary at registration time, preventing any updates from being seen by the handler.
